### PR TITLE
Added parametrization of rss feed names.

### DIFF
--- a/src/leiningen/new/cryogen/README.md
+++ b/src/leiningen/new/cryogen/README.md
@@ -63,7 +63,8 @@ The site configuration file is found at `resources/config.edn`, this file looks 
  :tag-root "tags"
  :page-root "pages"
  :tags? true
- :blog-prefix nil}
+ :blog-prefix nil
+ :rss-name "feed.xml"}
 ```
 
 ### Creating Posts

--- a/src/leiningen/new/cryogen/src/cryogen/compiler.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/compiler.clj
@@ -176,6 +176,7 @@
         [navbar-pages sidebar-pages] (group-pages pages)
         posts-by-tag (group-by-tags posts)
         posts (tag-posts posts)
+        rss-name (if-let [rssn (:rss-name config)] rssn "rss.xml")
         default-params {:title         (:site-title config)
                         :tags          (map tag-info (keys posts-by-tag))
                         :latest-posts  (->> posts (take 2) vec)
@@ -183,7 +184,7 @@
                         :sidebar-pages sidebar-pages
                         :archives-uri  (str (blog-prefix) "/archives.html")
                         :index-uri     (str (blog-prefix) "/index.html")
-                        :rss-uri       (str (blog-prefix) "/rss.xml")}]
+                        :rss-uri       (str (blog-prefix) "/" rss-name)}]
     (println (blue "copying resources"))
     (copy-resources (blog-prefix))
     (compile-pages default-params pages)
@@ -194,7 +195,7 @@
     (println (blue "generating site map"))
     (spit (str public (blog-prefix) "/sitemap.xml") (sitemap/generate (:site-url config)))
     (println (blue "generating rss"))
-    (spit (str public (blog-prefix) "/rss.xml") (rss/make-channel config posts))))
+    (spit (str public (blog-prefix) "/" rss-name) (rss/make-channel config posts))))
 
 (defn compile-assets-timed []
   (time


### PR DESCRIPTION
This PR adds the possibility to parametrize the rss feed name. 
As it turns out, sometimes you need to call your rss something other than "rss.xml", I for instance use - and communicated "feed.xml" to other aggregators.
If you specifiy ":rss-name" in the config.edn file, say "feed.xml", your feed will be found at this address. If you put nothing, this will fall back to "rss.xml".
Please do test this functionality, I was not able to do so as I did not grab how to do to test leiningen plugins...
