### PR TITLE
git command processing from pages/posts

### DIFF
--- a/src/leiningen/new/cryogen/html/layouts/git_gist.html
+++ b/src/leiningen/new/cryogen/html/layouts/git_gist.html
@@ -1,0 +1,13 @@
+{% block content %}
+<div id="gist">
+    <div id="gist-header">
+        <a class="gist-uri" 
+	   href="https://gist.github.com{{id}}"
+	   title="{{language}}">
+	  <h2>{{name}}</h2></a>
+    </div>
+    <pre id="gist-content">
+      {{content}}
+    </pre>
+</div>
+{% endblock %}

--- a/src/leiningen/new/cryogen/html/layouts/git_src.html
+++ b/src/leiningen/new/cryogen/html/layouts/git_src.html
@@ -1,0 +1,13 @@
+{% block content %}
+<div id="git">
+    <div id="git-header">
+        <a class="git-uri" 
+	   href="{{uri}}"
+	   title="{{name}}">
+	  <h2>{{name}}</h2></a>
+    </div>
+    <pre id="git-content">
+      {{content}}
+    </pre>
+</div>
+{% endblock %}

--- a/src/leiningen/new/cryogen/src/cryogen/commands.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/commands.clj
@@ -1,0 +1,37 @@
+(ns cryogen.commands
+  "command parsing from pages and posts written"
+  (:require [cryogen.github :as git]
+            [selmer.parser :refer [render]]
+            [clojure.java.io :as io]))
+
+(defn format-replace [r t] (prn r t)
+  (render (slurp (io/resource (str "../resources/templates/html/layouts/" t)))
+          r))
+
+(defn command [r] 
+  "command w/args to be parsed and formatted"
+  (let [cmds {"git-src" #(-> (git/get-src %) (format-replace "git_src.html"))
+              "git-gist" #(-> (git/get-gist %) (format-replace "git_gist.html"))}]
+    (get cmds r)))
+
+(defn find-and-call [pp]
+  (for [_ (re-seq #"\{\{(.+?)}\}" pp)]
+    (if-let [r (let [rem (clojure.string/split (second _) #"\s+")]
+                 (when-let [cm (command (first rem))]
+                   (if (rest rem)
+                     (apply cm (rest rem))
+                     (cm))))]
+      {:match (first _) :replace r})))
+
+(defn post-process [s]
+  (loop [_pp s
+         cm (find-and-call _pp)]
+    (if (empty? cm)
+      _pp
+      (recur 
+       (if-let [s (:match (first cm))]
+         (clojure.string/replace _pp s
+                                 (or (:replace (first cm))
+                                     ""))
+         _pp)
+       (rest cm)))))


### PR DESCRIPTION
I probably should have just used selmer but figuring out how to parse and utilize a function with an overload was complicated/I didn't understand it. The layouts are post-process layouts, so it's what the git code gets turned in to and replaced into the page/post, after selmer processes it from compile.clj. I didn't upload compile.clj yet since I created a bug report for io.clj so I am hesitant. It's basically like this: 

``` clojure
(defn compile-posts [default-params posts]
  (when-not (empty? posts)
    (println (blue "compiling posts"))
    (create-folder (str (blog-prefix) post-root))
    (doseq [post posts]
      (println "\t-->" (cyan (:uri post)))
      (spit (str public (:uri post))
            (-> (render-file (str "templates/html/layouts/" (:layout post))
                         (merge default-params
                                {:servlet-context "../"
                                 :post            post}))
                post-process))))) ;;note: post-process here
```

In a post you'd write in:
{{git-src https://github.com/viperscape/kuroshio/blob/master/examples/pubsub.clj}}
or
{{git-gist https://gist.github.com/viperscape/cec68f0791687f5959f1}}

And that is replaced with the code, after it has been processed through the git template.

Also, I do not like the name commands.clj but there it is. You can add more post-processing commands pretty easily from here on out.
