### PR TITLE
old compojure entry (duplicated) removed

### DIFF
--- a/src/leiningen/new/cryogen/project.clj
+++ b/src/leiningen/new/cryogen/project.clj
@@ -4,7 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [compojure "1.1.6"]
                  [hiccup "1.0.5"]
                  [selmer "0.7.2"]
                  [markdown-clj "0.9.57"


### PR DESCRIPTION
In the dependencies section, the compojure entry is duplicated - there are specified two version: 1.1.6 and 1.2.1
