### PR TITLE
Adds Locale "en" for groups in archives

### DIFF
--- a/src/leiningen/new/cryogen/src/cryogen/compiler.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/compiler.clj
@@ -65,7 +65,7 @@
          :toc (if (:toc page-meta) (generate-toc content))}
         (if is-post?
           {:date          (parse-post-date file-name)
-           :archive-group (.format (java.text.SimpleDateFormat. "yyyy MMMM") (parse-post-date file-name))
+           :archive-group (.format (java.text.SimpleDateFormat. "yyyy MMMM" (java.util.Locale "en")) (parse-post-date file-name))
            :uri           (post-uri file-name config)
            :tags          (set (:tags page-meta))}
           {:uri        (page-uri file-name config)


### PR DESCRIPTION
MMMM in the SimpleDateFormat constructor is replaced with the month name
of the default locale. The date:longDate filter of Selmer in Archives.html
generates a format with english month names. On non-english Systems that
leads to months names in the local language for the group names, but
english month names for the full dates on the post. To be consistent, the
locale "en" gets set manually on the SimpleDateFormatter constructor call.
This results in english month names on the archives page.

Fixes #16 
