### PR TITLE
Adds UTF-8 encoding to getBytes for html in TOC generation

### DIFF
--- a/src/leiningen/new/cryogen/src/cryogen/toc.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/toc.clj
@@ -19,7 +19,7 @@
 
 (defn generate-toc [html]
   (-> html
-      (.getBytes)
+      (.getBytes "UTF-8")
       (java.io.ByteArrayInputStream.)
       (html/parse)
       :content


### PR DESCRIPTION
getBytes was called without an encoding specification, garbling non-ASCII
characters that have not been encoded in the html source file. Fixes #24
