### PR TITLE
Add support for :ignored-files config key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+pom.xml
+/target

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ The site configuration file is found at `templates/config.edn`, this file looks 
  :resources        ["css" "js" "img"]
  :keep-files       [".git"] 
  :disqus?          false
- :disqus-shortname ""}
+ :disqus-shortname ""
+ :ignored-files    [#"^\.#.*" #".*\.swp$"]}
 ```
 
   * `post-root` - value prepended to all post uri's
@@ -85,6 +86,7 @@ The site configuration file is found at `templates/config.edn`, this file looks 
   * `keep-files` - list of folders or files that are not wiped in the `public` directory. For example, this allows to keep a `.git` directory there across recompiles of the site to versionize the generated files
   * `disqus?` - set to true if you want disqus enabled on your site
   * `disqus-shortname` - your disqus shortname
+  * `ignored-files` - list of regexps matching files the compiler should ignore
 
 ### Creating Posts
 

--- a/src/leiningen/new/cryogen/config.edn
+++ b/src/leiningen/new/cryogen/config.edn
@@ -14,4 +14,5 @@
  :resources        ["css" "js" "404.html"]
  :keep-files       [".git"]
  :disqus?          false
- :disqus-shortname ""}
+ :disqus-shortname ""
+ :ignored-files    [#"\.#.*" #".*\.swp$"]}

--- a/src/leiningen/new/cryogen/project.clj
+++ b/src/leiningen/new/cryogen/project.clj
@@ -1,4 +1,4 @@
-(defproject cryogen "0.1.0"
+(defproject cryogen "0.1.1-SNAPSHOT"
             :description "Simple static site generator"
             :url "https://github.com/lacarmen/cryogen"
             :license {:name "Eclipse Public License"
@@ -7,7 +7,7 @@
                            [ring/ring-devel "1.3.2"]
                            [compojure "1.3.1"]
                            [ring-server "0.3.1"]
-                           [cryogen-core "0.1.8"]]
+                           [cryogen-core "0.1.9-SNAPSHOT"]]
             :plugins [[lein-ring "0.8.13"]]
             :main cryogen.core
             :ring {:init cryogen.server/init

--- a/src/leiningen/new/cryogen/src/cryogen/server.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/server.clj
@@ -7,7 +7,8 @@
 
 (defn init []
   (compile-assets-timed)
-  (start-watcher! "resources/templates" compile-assets-timed))
+  (let [ignored-files (-> (read-config) :ignored-files)]
+    (start-watcher! "resources/templates" ignored-files compile-assets-timed)))
 
 (defroutes handler
   (GET "/" [] (redirect (str (:blog-prefix (read-config)) "/index.html")))


### PR DESCRIPTION
Prevent the compiler from attempting to process files defined by a list of regexps. By default ignore emacs and vi backup files.

This change requires lacarmen/cryogen-core#4

Please also see my comment there about versions.
