### PR TITLE
Fix blue theme sizing bug due to CSS breakpoint

### DIFF
--- a/src/leiningen/new/cryogen/themes/blue/css/screen.css
+++ b/src/leiningen/new/cryogen/themes/blue/css/screen.css
@@ -128,9 +128,6 @@ pre, code, .hljs {
     .navbar-nav>li>a {
         padding: 30px 20px;
     }
-}
-
-@media (min-width: 400px) {
     .navbar-default .navbar-brand {
         font-size: 36px;
         padding: 25px 15px;
@@ -141,8 +138,7 @@ pre, code, .hljs {
     }
 }
 
-
-@media (max-width: 399px) {
+@media (max-width: 767px) {
     body{
         font-size: 14px;
     }

--- a/src/leiningen/new/cryogen/themes/blue_centered/css/screen.css
+++ b/src/leiningen/new/cryogen/themes/blue_centered/css/screen.css
@@ -159,9 +159,6 @@ pre, code, .hljs {
 }
 
 @media (max-width: 767px) {
-    .navbar-default .navbar-nav .open .dropdown-menu > li > a {
-        color: #fff;
-    }
     body{
         font-size: 14px;
     }

--- a/src/leiningen/new/cryogen/themes/blue_centered/css/screen.css
+++ b/src/leiningen/new/cryogen/themes/blue_centered/css/screen.css
@@ -148,9 +148,6 @@ pre, code, .hljs {
     .navbar-nav>li>a {
         padding: 30px 20px;
     }
-}
-
-@media (min-width: 400px) {
     .navbar-default .navbar-brand {
         font-size: 36px;
         padding: 25px 15px;
@@ -165,9 +162,6 @@ pre, code, .hljs {
     .navbar-default .navbar-nav .open .dropdown-menu > li > a {
         color: #fff;
     }
-}
-
-@media (max-width: 399px) {
     body{
         font-size: 14px;
     }


### PR DESCRIPTION
Fixes #68.

Earlier, I ran into #68 while playing around with a sample blog. I did some digging into why #68 was occurring. Turns out, there's a mismatch between the CSS responsive breakpoints. As a result, a certain range of medium screen widths were getting the large text with the small menu bar. This PR puts the CSS breakpoints in the custom `screen.css` of `blue` and `blue_centered` back in line with the "extra small" to "small" breakpoint from official Bootstrap (documented here http://getbootstrap.com/css/#grid-options and confirmed in Chrome web inspector's CSS tab).

Additionally, deletes a CSS rule I found in `blue_centered` which appears to be redundant, given that it applies identical styling to a less specific rule that it overrides.