### PR TITLE
Add default output dir to default .gitignore

### DIFF
--- a/src/leiningen/new/cryogen/gitignore
+++ b/src/leiningen/new/cryogen/gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 .lein-repl-history
 .lein-plugins/
 .lein-failures
+/resources/public/


### PR DESCRIPTION
This PR adds the default output location `/resources/public/` to the template's `.gitignore` file, so that by default, sites exclude generated output from version control. Since these files are purely derivative, leaving them out of version control does not lose any information, since they can be re-generated on demand.

I know this is a potentially opinionated change, and I'm not sure if this project's maintainers would agree with this opinion, so feel free to reject this PR if it doesn't line up with what you want for the project.

But, at least from my point of view, here are some benefits of this change for a typical user of Cryogen who version controls their site source with git:

* Reduce redundancy in diffs.
* Diffs become more readable.
* Slightly smaller git repository size.

Let me know what you think. Thanks.