### PR TITLE
Use dynamic copyright year in templates

### DIFF
--- a/src/leiningen/new/cryogen/themes/blue/html/base.html
+++ b/src/leiningen/new/cryogen/themes/blue/html/base.html
@@ -87,7 +87,7 @@
             </div>
         </div>
     </div>
-    <footer>Copyright &copy; 2015 {{author}}
+    <footer>Copyright &copy; {{today|date:yyyy}} {{author}}
         <p style="text-align: center;">Powered by <a href="http://cryogenweb.org">Cryogen</a></p></footer>
 </div>
 <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>

--- a/src/leiningen/new/cryogen/themes/blue_centered/html/base.html
+++ b/src/leiningen/new/cryogen/themes/blue_centered/html/base.html
@@ -82,7 +82,7 @@
             </div>
         </div>
     </div>
-    <footer>Copyright &copy; 2014 BLOGAWESOME
+    <footer>Copyright &copy; {{today|date:yyyy}} {{author}}
         <p style="text-align: center;">Powered by <a href="http://cryogenweb.org">Cryogen</a></p></footer>
 </div>
 <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>


### PR DESCRIPTION
Instead of a static year, which needs to be updated, use the Selmer date
filter in themes to output the current year. Also update the
blue_centered theme to output the authors name next to the copyright
year.