### PR TITLE
Blog/Page/Post/Tag uri customisation

### DIFF
--- a/src/leiningen/new/cryogen/config.edn
+++ b/src/leiningen/new/cryogen/config.edn
@@ -5,7 +5,10 @@
  :post-root          "posts"
  :tag-root           "tags"
  :page-root          "pages"
- :blog-prefix        "/blog"
+ :post-root-uri      "posts"
+ :tag-root-uri       "tags"
+ :page-root-uri      "pages"
+ :blog-prefix        "blog"
  :rss-name           "feed.xml"
  :rss-filters        ["cryogen"]
  :recent-posts       3

--- a/src/leiningen/new/cryogen/md/posts/2014-12-11-docs.md
+++ b/src/leiningen/new/cryogen/md/posts/2014-12-11-docs.md
@@ -203,10 +203,15 @@ The ` initHighlightingOnLoad` function is called in `templates/html/layouts/base
 To insert your static resources using md syntax:
 
 ```md
-![alt tag](/img/cryogen.png)
+![cryogen](img/cryogen.png)
+```
+To change the size of image with css
+
+``` css
+img[alt=cryogen] { width: 200px; }
 ```
 
-![alt tag](/img/cryogen.png)
+![cryogen](img/cryogen.png)
 
 
 ## Deploying Your Site

--- a/src/leiningen/new/cryogen/themes/blue/css/screen.css
+++ b/src/leiningen/new/cryogen/themes/blue/css/screen.css
@@ -121,6 +121,8 @@ pre, code, .hljs {
     background-color: #f7f9fd;
 }
 
+img[alt=cryogen] { width: 200px; }
+
 @media (min-width: 768px) {
     .navbar {
         min-height: 70px;

--- a/src/leiningen/new/cryogen/themes/blue_centered/css/screen.css
+++ b/src/leiningen/new/cryogen/themes/blue_centered/css/screen.css
@@ -138,6 +138,8 @@ pre, code, .hljs {
     background-color: #f7f9fd;
 }
 
+img[alt=cryogen] { width: 200px; }
+
 @media (min-width: 768px) {
     .navbar {
         min-height: 70px;


### PR DESCRIPTION
Add possibility to configure uri root directory for pages, posts and tags
via config params:
```
:page-root-uri
:post-root-uri
:tag-root-uri
````
- to place entity to the root directory use empty value (ex. :page-root-uri "")
- if parameter is not set corresponding {entity}-root parameter will be used
- set empty blog-prefix to use server root

Issues:
https://github.com/cryogen-project/cryogen-core/issues/32
https://github.com/cryogen-project/cryogen/issues/83

Related PR:
https://github.com/cryogen-project/cryogen-core/pull/56