### PR TITLE
Update file names in template

### DIFF
--- a/src/leiningen/new/cryogen.clj
+++ b/src/leiningen/new/cryogen.clj
@@ -57,7 +57,7 @@
                ["resources/templates/md/pages/another-page.md" (render "md/pages/another-page.md")]
                ["resources/templates/md/posts/2014-03-10-first-post.md" (render "md/posts/2014-03-10-first-post.md")]
                ["resources/templates/md/posts/2014-11-04-second-post.md" (render "md/posts/2014-11-04-second-post.md")]
-               ["resources/templates/md/posts/2014-12-11-docs.md" (render "md/posts/2014-12-11-docs.md")]
+               ["resources/templates/md/posts/2016-01-07-docs.md" (render "md/posts/2016-01-07-docs.md")]
                ;;Asciidoc templates
                ["resources/templates/asc/pages/adoc-page.asc" (render "asc/pages/adoc-page.asc")]
                ["resources/templates/asc/posts/2014-10-10-adoc-post.asc" (render "asc/posts/2014-10-10-adoc-post.asc")]


### PR DESCRIPTION
A recent commit changed the name of a file in the template, causing `lein new cryogen` to fail with `Template resource 'leiningen/new/cryogen/md/posts/2014-12-11-docs.md' not found.`

I think this change will fix the issue.