### PR TITLE
Serve `index.html` from subdirs when `clean-urls?` true.

### DIFF
--- a/src/leiningen/new/cryogen/src/cryogen/server.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/server.clj
@@ -1,10 +1,12 @@
 (ns cryogen.server
   (:require [compojure.core :refer [GET defroutes]]
             [compojure.route :as route]
-            [ring.util.response :refer [redirect]]
+            [ring.util.response :refer [redirect resource-response]]
+            [ring.util.codec :refer [url-decode]]
             [cryogen-core.watcher :refer [start-watcher!]]
             [cryogen-core.plugins :refer [load-plugins]]
-            [cryogen-core.compiler :refer [compile-assets-timed read-config]]))
+            [cryogen-core.compiler :refer [compile-assets-timed read-config]]
+            [cryogen-core.io :refer [path]]))
 
 (defn init []
   (load-plugins)
@@ -12,7 +14,19 @@
   (let [ignored-files (-> (read-config) :ignored-files)]
     (start-watcher! "resources/templates" ignored-files compile-assets-timed)))
 
+(defn wrap-subdirectories
+  [handler]
+  (fn [request]
+    (let [req-uri (.substring (url-decode (:uri request)) 1)
+          res-path (path req-uri (when (:clean-urls? (read-config)) "index.html"))]
+      (or (resource-response res-path {:root "public"})
+          (handler request)))))
+
 (defroutes handler
-  (GET "/" [] (redirect (str (:blog-prefix (read-config)) "/index.html")))
+  (GET "/" [] (redirect (let [config (read-config)]
+                          (path (:blog-prefix (read-config)) "/"
+                                (when-not (:clean-urls? config) "index.html")))))
   (route/resources "/")
   (route/not-found "Page not found"))
+
+(def app (wrap-subdirectories handler))


### PR DESCRIPTION
#104 
Sorry it took so long.

Adds a `wrap-subdirectories` middleware to serve up a heaping helping of `index.html` goodness.

It can instead be done by regex-matching the routes. It would be less general, but also less code.