### PR TITLE
Add canonical link to head in both themes

### DIFF
--- a/src/leiningen/new/cryogen/themes/blue/html/base.html
+++ b/src/leiningen/new/cryogen/themes/blue/html/base.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <title>{{title}}{% block subtitle %}{% endblock %}</title>
+    <link rel="canonical" href="{{site-url}}{{uri}}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='http://fonts.googleapis.com/css?family=Alegreya:400italic,700italic,400,700' rel='stylesheet'
           type='text/css'>

--- a/src/leiningen/new/cryogen/themes/blue_centered/html/base.html
+++ b/src/leiningen/new/cryogen/themes/blue_centered/html/base.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <title>{{title}}{% block subtitle %}{% endblock %}</title>
+    <link rel="canonical" href="{{site-url}}{{uri}}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='http://fonts.googleapis.com/css?family=Alegreya:400italic,700italic,400,700' rel='stylesheet'
           type='text/css'>


### PR DESCRIPTION
Hi,

This is just a tiny tweak to add canonical links to generated pages/posts.
Can be seen in action at [https://matthewsiemens.com](https://matthewsiemens.com)

Please let me know if there are any concerns about this.

Thanks!