### PR TITLE
Remove blog from list of cryogen blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ More information on deployment can be found [here](http://cryogenweb.org/docs/de
 * [dl1ely.github.io](http://dl1ely.github.io)
 * [nil/recur](http://jonase.github.io/nil-recur)
 * [on the clojure move](http://tangrammer.github.io/)
-* [cognizance](http://blog.jethrokuan.com/)
 * [AGYNAMIX Site & Blog](http://www.agynamix.de)
 * [e-Resident Me](http://eresident.me)
 * [Chad Stovern's blog](http://www.chadstovern.com)


### PR DESCRIPTION
I've since moved to Hugo for my blog generation, not that cryogen was particularly lacking, but I needed something in Go that I could explore and use.

I noticed someone starring my blog, and the only logical link being cryogen, so I'm removing it to prevent further confusion.