### PR TITLE
Document that you can just do `lein run` to generate the HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ The ` initHighlightingOnLoad` function is called in `{theme}/html/base.html`.
 ## Deploying Your Site
 
 The generated static content will be found under the `resources/public` folder. Simply copy the content to a static
-folder for a server such as Nginx or Apache and your site is now ready for service.
+folder for a server such as Nginx or Apache and your site is now ready for
+service. You can re-generate the content by running `lein run`.
 
 A sample Nginx configuration that's placed in `/etc/nginx/sites-available/default` can be seen below:
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ lein ring server
 
 The server will watch for changes in the `resources/templates` folder and recompile the content automatically.
 
+You can also generate the content without bringing up a server via:
+
+```
+lein run
+```
+
 ### Site Configuration
 
 The site configuration file is found at `templates/config.edn`, this file looks as follows:
@@ -134,8 +140,7 @@ The ` initHighlightingOnLoad` function is called in `{theme}/html/base.html`.
 ## Deploying Your Site
 
 The generated static content will be found under the `resources/public` folder. Simply copy the content to a static
-folder for a server such as Nginx or Apache and your site is now ready for
-service. You can re-generate the content by running `lein run`.
+folder for a server such as Nginx or Apache and your site is now ready for service.
 
 A sample Nginx configuration that's placed in `/etc/nginx/sites-available/default` can be seen below:
 


### PR DESCRIPTION
I spent like 10 minutes googling around trying to figure out how to build Cryogen in a shell script before I found https://github.com/cryogen-project/cryogen/issues/79. I think this information belongs in the docs - this seems like a reasonable place.