### PR TITLE
Update for some CSS/Sass inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ The site configuration file is found at `templates/config.edn`, this file looks 
  :recent-posts       3
  :post-date-format   "yyyy-MM-dd"
  :sass-src           nil
- :sass-dest          nil
  :sass-path          "sass"
  :compass-path       "compass"
  :theme              "blue"

--- a/src/leiningen/new/cryogen.clj
+++ b/src/leiningen/new/cryogen.clj
@@ -83,6 +83,8 @@
              ["project.clj" (render "project.clj")]
              ;;static resources
              ["resources/templates/img/cryogen.png" (resource "img/cryogen.png")]
+             ["resources/templates/css/example.css" (resource "css/example.css")]
+             ["resources/templates/css/sassexample.scss" (resource "css/sassexample.scss")]
              ;;Markdown templates
              ["resources/templates/md/pages/about.md" (render "md/pages/about.md")]
              ["resources/templates/md/pages/another-page.md" (render "md/pages/another-page.md")]

--- a/src/leiningen/new/cryogen/config.edn
+++ b/src/leiningen/new/cryogen/config.edn
@@ -14,11 +14,10 @@
  :recent-posts       3
  :post-date-format   "yyyy-MM-dd"
  :sass-src           nil
- :sass-dest          nil
  :sass-path          "sass"
  :compass-path       "compass"
  :theme              "blue"
- :resources          ["img"]
+ :resources          ["img" "css"]
  :keep-files         [".git"]
  :disqus?            false
  :disqus-shortname   ""

--- a/src/leiningen/new/cryogen/css/example.css
+++ b/src/leiningen/new/cryogen/css/example.css
@@ -1,0 +1,3 @@
+a {
+    text-decoration-style: dashed;
+}

--- a/src/leiningen/new/cryogen/css/sassexample.scss
+++ b/src/leiningen/new/cryogen/css/sassexample.scss
@@ -1,0 +1,5 @@
+body {
+    a {
+        text-decoration-style: dashed;
+    }
+}

--- a/src/leiningen/new/cryogen/md/posts/2016-01-07-docs.md
+++ b/src/leiningen/new/cryogen/md/posts/2016-01-07-docs.md
@@ -65,7 +65,6 @@ The site configuration file is found at `templates/config.edn`, this file looks 
  :recent-posts       3
  :post-date-format   "yyyy-MM-dd"
  :sass-src           nil
- :sass-dest          nil
  :sass-path          "sass"
  :compass-path       "compass"
  :theme              "blue"


### PR DESCRIPTION
1. Created `css` dir, with example CSS and Sass files inside, and added it to `:resources` list.
2. Removed `:sass-dest` key from config.edn (will still work with old cryogen-core, since it’ll default to `css` if missing) - upcoming cryogen-core changes always compile Sass to same directory
3. Updated docs to remove references to `:sass-dest`

Related to [this cryogen-core PR](https://github.com/cryogen-project/cryogen-core/pull/91). They should be deployed simultaneously.