### PR TITLE
Fix blockquote footers in default css

### DIFF
--- a/src/leiningen/new/cryogen/md/posts/2014-03-10-first-post.md
+++ b/src/leiningen/new/cryogen/md/posts/2014-03-10-first-post.md
@@ -6,4 +6,5 @@
 
 some stuff happened
 
->and a quote appeared
+> Stop trying to make fetch happen.
+>- Regina

--- a/src/leiningen/new/cryogen/themes/blue/css/screen.css
+++ b/src/leiningen/new/cryogen/themes/blue/css/screen.css
@@ -82,6 +82,12 @@ footer {
     padding-bottom: 30px;
 }
 
+blockquote footer {
+    text-align: left;
+    padding-top: 0px;
+    padding-bottom: 0px;
+}
+
 #post-tags {
     margin-top: 30px;
 }

--- a/src/leiningen/new/cryogen/themes/blue_centered/css/screen.css
+++ b/src/leiningen/new/cryogen/themes/blue_centered/css/screen.css
@@ -99,6 +99,12 @@ footer {
     padding-bottom: 30px;
 }
 
+blockquote footer {
+    text-align: left;
+    padding-top: 0px;
+    padding-bottom: 0px;
+}
+
 #post-tags {
     margin-top: 30px;
 }


### PR DESCRIPTION
The default CSS footer style made blockquote footers look broken.

markdown-clj supports blockquotes with `>` and blockquote footers with `>-`.  I updated a sample post to show usage.
