### PR TITLE
fix printouts of Lotus-themed pages

### DIFF
--- a/src/leiningen/new/cryogen/themes/lotus/css/_menu.scss
+++ b/src/leiningen/new/cryogen/themes/lotus/css/_menu.scss
@@ -132,3 +132,10 @@
     }
   }
 }
+
+// hides menu in printed pages
+@media print {
+  #menucont {
+    display: none !important;
+  }
+}

--- a/src/leiningen/new/cryogen/themes/lotus/css/blog.scss
+++ b/src/leiningen/new/cryogen/themes/lotus/css/blog.scss
@@ -48,6 +48,9 @@ a {
   @media screen and (min-width: $mobile-breakpoint) {
     display: none;
   }
+  @media print {
+    display: none !important;
+  }
 }
 
 .desktop-and-tablet-only {


### PR DESCRIPTION
* the site caption was displayed twice in printouts (fixed)
* the (useless) menu was showing up in printouts (fixed)