### PR TITLE
Lotus: fix non-unique id in previews

### DIFF
--- a/src/leiningen/new/cryogen/themes/lotus/html/previews.html
+++ b/src/leiningen/new/cryogen/themes/lotus/html/previews.html
@@ -4,7 +4,7 @@
     {% for post in posts %}
     <div class="post-header">
         <h1>{{post.title}}</h1>
-        <div id="post-meta">
+        <div class="post-meta">
             {% if post.author %}
             <div class="author">{{post.author}}</div>
             {% endif %}


### PR DESCRIPTION
change `id=post-meta` to `class=`. It doesn't seem to be actually used in any CSS so it is safe to do and improves web.dev ranking :)