### PR TITLE
Handle case where blog-prefix is blank

### DIFF
--- a/src/leiningen/new/cryogen/src/cryogen/server.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/server.clj
@@ -34,7 +34,9 @@
                        :no-trailing-slash (if (or (= req-uri "")
                                                   (= req-uri "/")
                                                   (= req-uri
-                                                     (.substring blog-prefix 1)))
+                                                     (if (string/blank? blog-prefix)
+                                                       blog-prefix
+                                                       (.substring blog-prefix 1))))
                                             (path req-uri "index.html")
                                             (path (str req-uri ".html")))
                        :dirty (path (str req-uri ".html")))


### PR DESCRIPTION
I set blog-prefix to an empty string. When using `clean-urls :no-trailing-slash` and an empty blog-prefix, the call to .substring fails. This handles the condition when using `lein ring server` during testing/blog preview.

Likely not the best solution, but it works.