### PR TITLE
Use Markup protocol defined in cryogen-core.markup

### DIFF
--- a/src/leiningen/new/cryogen/src/cryogen/markup.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/markup.clj
@@ -1,16 +1,12 @@
 (ns cryogen.markup
   (:require [markdown.core :refer [md-to-html-string]]
-            [clojure.string :as s])
+            [clojure.string :as s]
+            [cryogen-core.markup :as m])
   (:import org.asciidoctor.Asciidoctor$Factory
            java.util.Collections))
 
-(defprotocol Markup
-  (dir [this])
-  (ext [this])
-  (render-fn [this]))
-
 (defn- markdown []
-  (reify Markup
+  (reify m/Markup
     (dir [this] "md")
     (ext [this] ".md")
     (render-fn [this]
@@ -22,7 +18,7 @@
          :heading-anchors true)))))
 
 (defn- asciidoc []
-  (reify Markup
+  (reify m/Markup
     (dir [this] "asc")
     (ext [this] ".asc")
     (render-fn [this]


### PR DESCRIPTION
Just noticed that the `Markup` protocol is redefined in `markup.clj`, even though it's already defined in the `cryogen-core.markup` namespace.
We can just the protocol defined in `cryogen-core.markup` namespace. 
Less code is always good IMO!