### PR TITLE
Support for deps tools instead of lein

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 pom.xml
 /target
 .nrepl-port
+.lein-deps-sum
+.lein-repl-history
+.lein-plugins/
+.lein-failures

--- a/README.md
+++ b/README.md
@@ -39,20 +39,38 @@ A new site can be created using the Cryogen template as follows:
 lein new cryogen my-blog
 ```
 
+or, alternatively, using [`clj-new`](https://github.com/seancorfield/clj-new/) (and having defined the `new` profile, as it suggests):
+
+```
+clojure -X:new create :template cryogen :name me/my-blog
+```
+
 ### Running the Server
 
-The web server can be started from the `my-blog` directory using the `lein-ring` plugin:
+The web server can be started from the `my-blog` directory using either the `lein-ring` plugin:
 
 ```
 lein ring server
 ```
 
+or tools-deps:
+
+```
+clojure -X:serve
+```
+
 The server will watch for changes in the `content` and `themes` folders and recompile the content automatically.
 
-You can also generate the content without bringing up a server via:
+You can also generate the content without bringing up a server either via:
 
 ```
 lein run
+```
+
+or via:
+
+```
+clojure -M:build
 ```
 
 ### Site Configuration

--- a/src/leiningen/new/cryogen.clj
+++ b/src/leiningen/new/cryogen.clj
@@ -110,6 +110,7 @@
              options
              [".gitignore" (render "gitignore")]
              ["project.clj" (render "project.clj")]
+             ["deps.edn" (render "deps.edn")]
              ;;static resources
              ["content/img/cryogen.png" (resource "img/cryogen.png")]
              ["content/css/example.css" (resource "css/example.css")]

--- a/src/leiningen/new/cryogen/deps.edn
+++ b/src/leiningen/new/cryogen/deps.edn
@@ -1,0 +1,13 @@
+{:deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        ring/ring-devel {:mvn/version "1.8.2"}
+        compojure/compojure {:mvn/version "1.6.2"}
+        ring-server/ring-server {:mvn/version "0.5.0"}
+        cryogen-flexmark/cryogen-flexmark {:mvn/version "0.1.4"}
+        cryogen-core/cryogen-core {:mvn/version "0.3.2"}}
+
+ :aliases {;; Run with `clojure -M:build`
+           :build {:main-opts ["-m" "cryogen.core"]}
+           ;; Start a server serving the blog: `clojure -X:serve`
+           ;; (requires tools-deps 0.9.745+)
+           :serve {:exec-fn   cryogen.server/serve
+                   :exec-args {:port 8888}}}}

--- a/src/leiningen/new/cryogen/gitignore
+++ b/src/leiningen/new/cryogen/gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 .lein-plugins/
 .lein-failures
 /public/
+.cpcache/

--- a/src/leiningen/new/cryogen/src/cryogen/server.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/server.clj
@@ -5,6 +5,7 @@
    [compojure.route :as route]
    [ring.util.response :refer [redirect file-response]]
    [ring.util.codec :refer [url-decode]]
+   [ring.server.standalone :as ring-server]
    [cryogen-core.watcher :refer [start-watcher!]]
    [cryogen-core.plugins :refer [load-plugins]]
    [cryogen-core.compiler :refer [compile-assets-timed]]
@@ -53,3 +54,10 @@
   (route/not-found "Page not found"))
 
 (def handler (wrap-subdirectories routes))
+
+(defn serve
+  "Entrypoint for running via tools-deps (`clojure -X:serve`)"
+  [opts]
+  (ring-server/serve
+    handler
+    (merge {:init init} opts)))


### PR DESCRIPTION
With this change you can use clj-new
(or still lein new) and then use the
clojure CLI instead of leiningen to build/
serve the site.

An advantage is that it is possible to switch
to versions of libraries based on local paths or
git URLs and SHAs.