### PR TITLE
git-ignore lotus' sass-generated files

### DIFF
--- a/src/leiningen/new/cryogen/gitignore
+++ b/src/leiningen/new/cryogen/gitignore
@@ -10,4 +10,6 @@ pom.xml.asc
 .lein-plugins/
 .lein-failures
 /public/
+/themes/lotus/css/blog.css
+/themes/lotus/css/blog.css.map
 .cpcache/


### PR DESCRIPTION
These files showed up after switching the theme to `lotus`:
```
Untracked files:                               
  (use "git add <file>..." to include in what will be committed)
        themes/lotus/css/blog.css
        themes/lotus/css/blog.css.map
```