### PR TITLE
server.clj: enable auto-refresh in the fast mode

### DIFF
--- a/src/leiningen/new/cryogen/md/posts/2020-12-03-docs.md
+++ b/src/leiningen/new/cryogen/md/posts/2020-12-03-docs.md
@@ -34,10 +34,12 @@ A new site can be created using the Cryogen template as follows:
 lein new cryogen my-blog
 ```
 
-or, alternatively, using [`clj-new`](https://github.com/seancorfield/clj-new/) (and having defined the `new` profile, as it suggests):
+or, alternatively, using `clj-new as a tool`](https://github.com/seancorfield/clj-new#installation-as-a-tool):
 
 ```
-clojure -X:new create :template cryogen :name me.my-blog
+clojure -Ttools install com.github.seancorfield/clj-new '{:git/tag "v1.2.362"}' :as clj-new # update to latest!
+clojure -Tclj-new create :template cryogen :name myname/myblog :force true
+cd myname/myblog/
 ```
 
 ### Running the Server
@@ -55,6 +57,12 @@ clojure -X:serve # or clojure -X:serve:fast
 ```
 
 The server will watch for changes in the `content` and `themes` folders and recompile the content automatically. The `*:fast` variants perform [fast but partial compilation](https://cryogenweb.org/docs/fast-compilation.html) of only the changed page/post.
+
+#### Changing the port
+
+You can either change the hard-coded port in `deps.edn` / `server.clj` or override it by setting the PORT env var.
+
+### Building the static site
 
 You can also generate the content without bringing up a server either via:
 

--- a/src/leiningen/new/cryogen/src/cryogen/server.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/server.clj
@@ -1,32 +1,38 @@
 (ns cryogen.server
-  (:require 
-   [clojure.string :as string]
-   [compojure.core :refer [GET defroutes]]
-   [compojure.route :as route]
-   [ring.util.response :refer [redirect file-response]]
-   [ring.util.codec :refer [url-decode]]
-   [ring.server.standalone :as ring-server]
-   [cryogen-core.watcher :refer [start-watcher! start-watcher-for-changes!]]
-   [cryogen-core.plugins :refer [load-plugins]]
-   [cryogen-core.compiler :refer [compile-assets-timed]]
-   [cryogen-core.config :refer [resolve-config]]
-   [cryogen-core.io :refer [path]]))
+  (:require
+    [compojure.core :refer [GET defroutes]]
+    [compojure.route :as route]
+    [ring.util.response :refer [redirect file-response]]
+    [ring.util.codec :refer [url-decode]]
+    [ring.server.standalone :as ring-server]
+    [cryogen-core.watcher :refer [start-watcher! start-watcher-for-changes!]]
+    [cryogen-core.plugins :refer [load-plugins]]
+    [cryogen-core.compiler :refer [compile-assets-timed]]
+    [cryogen-core.config :refer [resolve-config]]
+    [cryogen-core.io :refer [path]]
+    [clojure.string :as string])
+  (:import (java.io File)))
+
+(def resolved-config (delay (resolve-config)))
+
+(def extra-config-dev
+  "Add dev-time configuration overrides here, such as `:hide-future-posts? false`"
+  {})
 
 (defn init [fast?]
-  (println "Init: fast compile enabled = " (boolean fast?))
   (load-plugins)
-  (compile-assets-timed)
-  (let [ignored-files (-> (resolve-config) :ignored-files)]
+  (compile-assets-timed extra-config-dev)
+  (let [ignored-files (-> @resolved-config :ignored-files)]
     (run!
       #(if fast?
-         (start-watcher-for-changes! % ignored-files compile-assets-timed {})
+         (start-watcher-for-changes! % ignored-files compile-assets-timed extra-config-dev)
          (start-watcher! % ignored-files compile-assets-timed))
       ["content" "themes"])))
 
 (defn wrap-subdirectories
   [handler]
   (fn [request]
-    (let [{:keys [clean-urls blog-prefix public-dest]} (resolve-config)
+    (let [{:keys [clean-urls blog-prefix public-dest]} @resolved-config
           req-uri (.substring (url-decode (:uri request)) 1)
           res-path (if (or (.endsWith req-uri "/")
                            (.endsWith req-uri ".html")
@@ -46,8 +52,15 @@
                                             (path (str req-uri ".html")))
                        :dirty (path (str req-uri ".html")))
                      req-uri)]
-      (or (file-response res-path {:root public-dest})
-          (handler request)))))
+        (or (let [rsp (file-response res-path {:root public-dest})
+                  body (:body rsp)]
+              ;; Add content-type; it cannot be derived from the extension if `:[no-]trailing-slash`
+              (cond-> rsp
+                      (and body
+                           (instance? File body)
+                           (string/ends-with? (.getName body) ".html"))
+                      (assoc-in [:headers "Content-Type"] "text/html")))
+            (handler request)))))
 
 (defroutes routes
   (GET "/" [] (redirect (let [config (resolve-config)]
@@ -61,10 +74,22 @@
 
 (defn serve
   "Entrypoint for running via tools-deps (clojure)"
-  [{:keys [fast] :as opts}]
+  [{:keys [fast join?] :as opts}]
   (ring-server/serve
     handler
-    (merge {:init (partial init fast)} opts)))
+    (merge
+      {:join? (if (some? join?) join? true)
+       :init (partial init fast)
+       :open-browser? true
+       :auto-refresh? fast ; w/o fast it would often try to reload the page before it has been fully compiled
+       :refresh-paths [(:public-dest @resolved-config)]}
+      opts)))
 
 (defn -main [& args]
-  (serve {:port 3000, :fast ((set args) "fast")}))
+  (serve {:port 3000 :fast ((set args) "fast")}))
+
+(comment
+  (def srv (serve {:join? false, :fast true}))
+  (.stop srv)
+
+  ,)


### PR DESCRIPTION
Enable auto-reloading of the blog's changed page in the browser if in the fast serve mode.

It only makes sense in the fast mode because the ring refresh middleware kicks in soon after it detects any change in the output dir - likely a while before Cryogen gets to compiling the page the user is currently viewing/editing - and thus it will try to load a url that it not yet available, resulting in Not Found.