### PR TITLE
lein ring server-headless throw artiyException

### DIFF
--- a/src/leiningen/new/cryogen/src/cryogen/server.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/server.clj
@@ -19,7 +19,7 @@
   "Add dev-time configuration overrides here, such as `:hide-future-posts? false`"
   {})
 
-(defn init [fast?]
+(defn init [& fast?]
   (load-plugins)
   (compile-assets-timed extra-config-dev)
   (let [ignored-files (-> @resolved-config :ignored-files)]


### PR DESCRIPTION
run : lein ring server-headless

throw: 
Syntax error (ArityException) compiling at (/tmp/form-init1283037664715307789.clj:1:73).
Wrong number of args (0) passed to: cryogen.server/init

Full report at:
/tmp/clojure-4781011244958579964.edn
Subprocess failed (exit code: 1)