### PR TITLE
Add missing :exec-fn to the :fast alias in deps.edn.

### DIFF
--- a/src/leiningen/new/cryogen/root/deps.edn
+++ b/src/leiningen/new/cryogen/root/deps.edn
@@ -10,4 +10,5 @@
            ;; Requires tools.deps.alpha 0.9.810+
            :serve {:exec-fn   cryogen.server/serve
                    :exec-args {:port 3000}}
-           :fast {:exec-args {:fast true}}}}
+           :fast {:exec-fn   cryogen.server/serve
+                  :exec-args {:fast true}}}}


### PR DESCRIPTION
Without this, it fails when running:

```
No function found on command line or in :exec-fn
```