### PR TITLE
Update Lotus Theme README.md with sass directions

### DIFF
--- a/src/leiningen/new/cryogen/themes/lotus/README.md
+++ b/src/leiningen/new/cryogen/themes/lotus/README.md
@@ -3,6 +3,8 @@ An elegant and responsive theme for Cryogen by [Matthew Davidson](https://github
 
 # Install
 
-1. Change the `:theme` key in `content/config.edn` to "lotus".
-2. Replace the GitHub and LinkedIn links in `base.html` with links to your own profiles. (More social media icons can be found in `icons.svg`.)
-3. Replace the white lotus logo with the logo of your choice in `base.html`.
+1. Install [sass](https://sass-lang.com/install).
+2. Set the `:sass-path` key in `content/config.edn` to where `sass` was installed. If it was installed globally, leave it as `"sass"`.
+3. Change the `:theme` key in `content/config.edn` to `"lotus"`.
+4. Replace the GitHub and LinkedIn links in `base.html` with links to your own profiles. (More social media icons can be found in `icons.svg`.)
+5. Replace the white lotus logo with the logo of your choice in `base.html`.


### PR DESCRIPTION
Added directions to install `sass` since it's a requirement for the Lotus Theme.