### PR TITLE
Fix character rendering issue

### DIFF
--- a/src/leiningen/new/cryogen/src/cryogen/server.clj
+++ b/src/leiningen/new/cryogen/src/cryogen/server.clj
@@ -59,7 +59,7 @@
                       (and body
                            (instance? File body)
                            (string/ends-with? (.getName body) ".html"))
-                      (assoc-in [:headers "Content-Type"] "text/html")))
+                      (assoc-in [:headers "Content-Type"] "text/html; charset=utf-8")))
             (handler request)))))
 
 (defroutes routes


### PR DESCRIPTION
Without charset=utf-8 in the Content-Type header, some characters get incorrectly. I was seeing question marks. UTF-8 is quite ubiquitous so I don't think it's worth detecting this by way of parsing the meta tag out of a theme.

Without:

![without-utf-8](https://user-images.githubusercontent.com/1719584/224570234-b690e237-03aa-44ed-a006-bc23db08017c.png)

With:

![with-utf-8](https://user-images.githubusercontent.com/1719584/224570190-85000d72-9e29-4397-b87b-7a272912c066.png)

